### PR TITLE
Add dockerfiles and ROS2 container

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY dockerfiles/install/i_dep.sh /tmp/i_dep.sh
+RUN bash /tmp/i_dep.sh && rm -rf /tmp/i_dep.sh
+
+WORKDIR /app
+
+CMD ["/bin/bash"]

--- a/dockerfiles/Dockerfile.windows
+++ b/dockerfiles/Dockerfile.windows
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY dockerfiles/install/i_dep.sh /tmp/i_dep.sh
+RUN bash /tmp/i_dep.sh && rm -rf /tmp/i_dep.sh
+
+WORKDIR /app
+
+CMD ["/bin/bash"]

--- a/dockerfiles/docker-compose.windows.yml
+++ b/dockerfiles/docker-compose.windows.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+
+services:
+  ros2-dev:
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile.windows
+    container_name: ros2_dev_container
+    volumes:
+      - ../:/app:cached
+    tty: true

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.9"
+
+services:
+  ros2-dev:
+    build:
+      context: ..
+      dockerfile: dockerfiles/Dockerfile
+    container_name: ros2_dev_container
+    volumes:
+      - ../:/app
+    tty: true

--- a/dockerfiles/install/i_dep.sh
+++ b/dockerfiles/install/i_dep.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Replace slow default mirrors with a faster one
+sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirror.kakao.com/ubuntu/|g' /etc/apt/sources.list
+sed -i 's|http://security.ubuntu.com/ubuntu/|http://mirror.kakao.com/ubuntu/|g' /etc/apt/sources.list
+
+apt-get update && apt-get install -y \
+    locales \
+    apt-transport-https \
+    ca-certificates \
+    curl gnupg2 lsb-release \
+    build-essential git \
+    python3-pip
+
+
+curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key \
+    -o /usr/share/keyrings/ros-archive-keyring.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] \
+http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
+    > /etc/apt/sources.list.d/ros2.list
+
+apt-get update
+
+apt-get install -y \
+    ros-humble-ros-core \
+    python3-colcon-common-extensions
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+
+echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc


### PR DESCRIPTION
Mục tiêu:

- Để chạy lại code của khách hàng trên nhiều môi trường Windows, Linux (chưa chạy được trên macos), docker container nên được sử dụng.


- Thành thạo việc viết Dockerfile và build image ROS2 theo yêu cầu dự án.


- Chuẩn bị môi trường container Ubuntu 22.04 có thể chạy được ROS2.

Task chi tiết:

- Tham khảo Dockerfile ROS2 Humble và folder structure trong
[https://github.com/nqtabokado/QpSolverCollection/tree/feature/implement-ros2-version-for-QpSolverCol...](https://github.com/nqtabokado/QpSolverCollection/tree/feature/implement-ros2-version-for-QpSolverCollection)
- Fork code từ https://github.com/chuoru/QpSolverCollection
branch ros2


- Mount volume source code ROS2 project trong máy vào container để phát triển code thuận tiện.


- Build image và chạy container, kiểm tra ROS2 có thể chạy được (ví dụ: chạy ros2 --version).


- Update [README.md](http://readme.md/) mô tả các bước build và run container



Output:

- Folder dockerfiles chứa docker-compose.yml, docker-compose.windows.yml, Dockerfile, [Dockerfile.windows](http://dockerfile.windows/), install/i_dep.sh

[Demo Video]:

https://github.com/user-attachments/assets/0d2018ae-650b-42b3-9789-a50764f298e4

